### PR TITLE
Fix to use Java's deprecated annotations instead of Kotlin's one

### DIFF
--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
@@ -326,6 +326,8 @@ internal class FeatureFlagJavaFileWriter(
     companion object {
         private const val FEATURE_FLAG_CLASS_NAME = "FeatureFlag"
 
+        // We specify annotation by name instead of `Class` to use `java.lang` package rather than
+        // `kotlin`.
         private const val DEPRECATED_ANNOTATION_CLASS_NAME = "Deprecated"
     }
 }

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
@@ -73,7 +73,7 @@ internal class FeatureFlagJavaFileWriter(
         val actualFlagValue = flag.value.toJavaValue(isRequiredLiteralValue)
 
         if (flag.hasOption(FeatureFlagOption.DEPRECATED)) {
-            emitAnnotation(Deprecated::class.java)
+            emitAnnotation(DEPRECATED_ANNOTATION_CLASS_NAME)
         }
         emitField(JavaType.BOOLEAN, flag.name, flag.getFieldModifier(), actualFlagValue)
     }
@@ -84,7 +84,7 @@ internal class FeatureFlagJavaFileWriter(
             val flagValue = flag.value.toJavaValue(true)
             println("$flagName = $flagValue")
             if (flag.hasOption(FeatureFlagOption.DEPRECATED)) {
-                emitAnnotation(Deprecated::class.java)
+                emitAnnotation(DEPRECATED_ANNOTATION_CLASS_NAME)
             }
             emitField(
                 JavaType.BOOLEAN,
@@ -325,5 +325,7 @@ internal class FeatureFlagJavaFileWriter(
 
     companion object {
         private const val FEATURE_FLAG_CLASS_NAME = "FeatureFlag"
+
+        private const val DEPRECATED_ANNOTATION_CLASS_NAME = "Deprecated"
     }
 }


### PR DESCRIPTION
It seems that we cannot refer Java's `@Deprecated` annotation class from Kotlin code, so use string literal instead.