### PR TITLE
Use relative path for FEATURE_FLAG_PROPERTY on FeatureFlagTask

### DIFF
--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -33,6 +33,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.util.VersionNumber
@@ -45,6 +47,7 @@ import java.io.File
 abstract class FeatureFlagTask : DefaultTask() {
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     internal abstract var sourceFile: File
 
     @get:OutputDirectory


### PR DESCRIPTION
https://guides.gradle.org/using-build-cache/#relocatability

And this might be useful on Jenkins build, because jenkins perform build on workspaces on each job name.
