### PR TITLE
Add maven-publish plugin for easy manual testing locally

### DIFF
--- a/feature-flag/build.gradle.kts
+++ b/feature-flag/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `java-gradle-plugin`
     id("org.jlleitschuh.gradle.ktlint") version Dependencies.Version.ktlintGradlePlugin
     id("com.github.ben-manes.versions") version Dependencies.Version.gradleVersionsPlugin
+    `maven-publish`
 }
 
 version = ModuleConfig.version
@@ -75,6 +76,16 @@ pluginBundle {
         "featureFlagPlugin" {
             displayName = "feature-flag-android"
             tags = listOf("android", "feature-flag", "feature-toggle")
+            version = ModuleConfig.version
+        }
+    }
+}
+
+publishing {
+    publications {
+        maybeCreate("pluginMaven", MavenPublication::class.java).apply {
+            groupId = ModuleConfig.groupId
+            artifactId = ModuleConfig.pluginId
             version = ModuleConfig.version
         }
     }


### PR DESCRIPTION
This PR will add `publishToMavenLocal` task which install artifact on local maven repository (~/.m2/repository).
And will help to test locally with mavenLocal() 