### PR TITLE
Added versionName property on featureFlag dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Definition of each property is as follows.
 - `packageName`: A package name of generated `FeatureFlag` class.
 - `phases`: A list of pairs of phase and the corresponding build variants.
 - `releasePhaseSet`: Build variants to allow using primitive boolean values as flag values. An optimizer may inline flag values with the variants. `buildType` or `flavor` can be specified as a variant.
+- `versionName`: (Optional) A version name which can override application version name.
+
+   Also, this property can be assigned for library module since Android Gradle Plugin 7.0 or higher.
 
 ## How to use
 

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
@@ -30,6 +30,7 @@ open class FeatureFlagExtension(project: Project) {
     var phases: Map<String, Set<BuildVariant.Element>> = mapOf()
     var releasePhaseSet: Set<BuildVariant.Element> = setOf()
     var packageName: String = ""
+    var versionName: String = ""
 
     fun buildType(name: String): BuildVariant.Element = BuildVariant.Element.BuildType(name)
 

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -57,8 +57,11 @@ class FeatureFlagPlugin : Plugin<Project> {
         val androidExtension = project.android as? BaseExtension
             ?: throw RuntimeException("`feature-flag` plugin requires any of android plugin")
 
-        val applicationVersionName = androidExtension.defaultConfig.versionName
-            ?: throw RuntimeException("Missing `android.defaultConfig.versionName` option")
+        val applicationVersionName = extension.versionName.takeIf(String::isNotEmpty)
+            ?: androidExtension.defaultConfig.versionName
+            ?: throw RuntimeException(
+                "Missing `featureFlag.versionName` or `android.defaultConfig.versionName` option"
+            )
 
         val localSourceFile = extension.sourceFile.takeIf(File::exists)
             ?: throw RuntimeException("Missing `sourceFile` option or file isn't exist")


### PR DESCRIPTION
Since Android Gradle Plugin 7.0, there is no way to assign `versionName` for library module.
So, we should add additional versionName property on featureFlag dsl.
And since compatibility issue, this property should be optional.

Fix #20