### PR TITLE
Mark FeatureFlagTask is not compatible with configuration cache

### DIFF
--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -30,7 +30,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.kotlin.dsl.create
-import org.gradle.util.GradleVersion
 import java.io.File
 
 /**

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -123,17 +123,18 @@ class FeatureFlagPlugin : Plugin<Project> {
     ): Map<String, Boolean> = phases.mapValues { it.value.any(currentBuildVariant::includes) }
 
     private fun markNotCompatibleWithConfigurationCache(task: Task) {
-        if (isConfigurationCacheAvailable) {
-            task.notCompatibleWithConfigurationCache(
+        try {
+            // Configuration cache method incubating in Gradle 7.4
+            val method = Task::class.java.getDeclaredMethod(
+                "notCompatibleWithConfigurationCache",
+                java.lang.String::class.java
+            )
+            method.invoke(
+                task,
                 "Requires Project instance to resolve build variants during task execution."
             )
+        } catch (ex: NoSuchMethodException) {
+            // pass
         }
-    }
-
-    companion object {
-        private val gradle_7_4 = GradleVersion.version("7.4")
-        private val gradle_current = GradleVersion.current()
-        // Configuration cache method incubating in Gradle 7.4
-        private val isConfigurationCacheAvailable = gradle_7_4 <= gradle_current
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix #24

Apply `notCompatibleWithConfigurationCache` on `FeatureFlagTask`
Inspired from https://github.com/google/play-services-plugins/commit/d15c96e

AS-IS:
```
./gradlew :app:assembleDebug \
    -Porg.gradle.unsafe.configuration-cache=true \
    -Porg.gradle.unsafe.configuration-cache-problems=fail

....
> Task :app:assembleDebug

FAILURE: Build failed with an exception.

* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:app:generateDebugFeatureFlag` of type `com.linecorp.android.featureflag.FeatureFlagTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

See the complete report at file:///xxxxx/build/reports/configuration-cache/9nkswwbntnkehnmvzs11etp17/1yr3icrhp0rgdmvo65u2f6cdi/configuration-cache-report.html
> Invocation of 'Task.project' by task ':app:generateDebugFeatureFlag' at execution time is unsupported.

BUILD FAILED in 1s

```

TO-BE:
```
./gradlew :app:assembleDebug \
    -Porg.gradle.unsafe.configuration-cache=true \
    -Porg.gradle.unsafe.configuration-cache-problems=fail

...

> Task :app:assembleDebug

1 problem was found storing the configuration cache.
- Task `:app:generateDebugFeatureFlag` of type `com.linecorp.android.featureflag.FeatureFlagTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

See the complete report at file:///xxxxx/build/reports/configuration-cache/9nkswwbntnkehnmvzs11etp17/1yr3icrhp0rgdmvo65u2f6cdi/configuration-cache-report.html
> Invocation of 'Task.project' by task ':app:generateDebugFeatureFlag' at execution time is unsupported.

BUILD SUCCESSFUL in 1s
```