### PR TITLE
Change to use package name for link type notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ An example is as follows.
 FLAG_1 = DEBUG              # Enabled when build in `DEBUG` phase.
 FLAG_2 = 1.2.0~             # Enabled when module version is `1.2.0` or later.
 FLAG_3 = @user              # Enabled if the username is `user`.
-FLAG_4 = submodule:FLAG_A   # Delegates flag enability to `FLAG_A` in module `submodule`.
+FLAG_4 = packageName:FLAG_A # Delegates flag enability to `FLAG_A` in module which has `packageName` as packageName property.
 
 # Property with options
 OVERRIDABLE FLAG_5 = DEBUG  # Makes the flag modifiable at runtime.

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagJavaFileWriter.kt
@@ -32,8 +32,7 @@ internal class FeatureFlagJavaFileWriter(
     private val outputDirectory: File,
     private val packageName: String,
     private val featureFlags: List<FeatureFlagData>,
-    private val isReleasePhase: Boolean,
-    private val moduleNameToFeatureFlagPackageMap: Map<String, String>
+    private val isReleasePhase: Boolean
 ) {
 
     fun write() {
@@ -267,13 +266,10 @@ internal class FeatureFlagJavaFileWriter(
         }
 
     private fun convertLinkToJavaLiteralValue(link: FlagLink): String {
-        if (link.moduleName.isEmpty()) {
+        if (link.packageName.isEmpty()) {
             return link.flagName
         }
-        val packageName = checkNotNull(moduleNameToFeatureFlagPackageMap[link.moduleName]) {
-            "Missing feature flag plugin on module ${link.moduleName}."
-        }
-        return "$packageName.FeatureFlag.${link.flagName}"
+        return "$${link.packageName}.FeatureFlag.${link.flagName}"
     }
 
     private fun wrapLiteral(literal: String): String = "Boolean.valueOf($literal)"

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -87,8 +87,9 @@ class FeatureFlagPlugin : Plugin<Project> {
         val localSourceFile = extension.sourceFile.takeIf(File::exists)
             ?: throw RuntimeException("Missing `sourceFile` option or file isn't exist")
 
-        val localPackageName = extension.packageName.takeIf(String::isNotEmpty)
-            ?: variant.namespace.orNull
+        val packageNameProvider = extension.packageName.takeIf(String::isNotEmpty)
+            ?.let { packageName -> project.provider { packageName } }
+            ?: variant.namespace
             ?: throw RuntimeException(
                 "Missing `featureFlag.packageName` or `android.namespace` option"
             )
@@ -107,7 +108,7 @@ class FeatureFlagPlugin : Plugin<Project> {
                 "Requires Project instance to resolve build variants during task execution."
             )
             sourceFile = localSourceFile
-            packageName = localPackageName
+            packageName.set(packageNameProvider)
             phaseMap = getPhaseMap(extension.phases, currentBuildVariant)
             isReleaseVariant = extension.releasePhaseSet.any(currentBuildVariant::includes)
             applicationVersionName = versionName

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import com.github.zafarkhaja.semver.Version
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 
 /**
  * A gradle task to generate feature flag Java file for the current module.
@@ -52,7 +53,7 @@ abstract class FeatureFlagTask : DefaultTask() {
     internal abstract val outputDirectory: DirectoryProperty
 
     @get:Input
-    internal abstract var packageName: String
+    internal abstract val packageName: Property<String>
 
     @get:Internal
     internal abstract var phaseMap: Map<String, Boolean>
@@ -106,7 +107,7 @@ abstract class FeatureFlagTask : DefaultTask() {
         }
         val writer = FeatureFlagJavaFileWriter(
             outputDirectoryFile,
-            packageName,
+            packageName.get(),
             featureFlags,
             isReleaseVariant
         )

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -26,7 +26,6 @@ import com.linecorp.android.featureflag.model.FeatureFlagData
 import com.linecorp.android.featureflag.model.FeatureFlagProperties
 import com.linecorp.android.featureflag.model.ForciblyOverriddenFeatureFlags
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -35,7 +34,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.findByType
 import java.io.File
 import com.github.zafarkhaja.semver.Version
 import org.gradle.api.file.DirectoryProperty
@@ -92,8 +90,6 @@ abstract class FeatureFlagTask : DefaultTask() {
     fun action() {
         val outputDirectoryFile = outputDirectory.asFile.get()
         outputDirectoryFile.deleteRecursively()
-        // Create mapping here instead of before task creation due to module configuration order.
-        val moduleNameToFeatureFlagPackageMap = createModuleToFeatureFlagPackageMap(project)
         val buildEnvironment = BuildEnvironment(
             phaseMap,
             Version.valueOf(applicationVersionName),
@@ -112,24 +108,10 @@ abstract class FeatureFlagTask : DefaultTask() {
             outputDirectoryFile,
             packageName,
             featureFlags,
-            isReleaseVariant,
-            moduleNameToFeatureFlagPackageMap
+            isReleaseVariant
         )
         writer.write()
     }
-
-    private fun createModuleToFeatureFlagPackageMap(project: Project): Map<String, String> =
-        project.rootProject.subprojects.mapNotNull(::getModuleToFeatureFlagPackagePairOrNull)
-            .toMap()
-
-    private fun getModuleToFeatureFlagPackagePairOrNull(project: Project): Pair<String, String>? {
-        val moduleName = project.path.substring(1) // To remove the leading ":"
-        val packageName = getFeatureFlagPackageOrNull(project) ?: return null
-        return moduleName to packageName
-    }
-
-    private fun getFeatureFlagPackageOrNull(project: Project): String? =
-        project.extensions.findByType<FeatureFlagExtension>()?.packageName
 
     private fun convertToFeatureFlagData(
         entry: FeatureFlagProperties.Entry,

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/FlagLink.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/FlagLink.kt
@@ -18,7 +18,8 @@ package com.linecorp.android.featureflag.model
 
 /**
  * A flag value element to refer to another flag value to decide enabled or not.
- * If a flag has a link with empty [moduleName], it means the linked and linking flags are in the
+ *
+ * If a flag has a link with empty [packageName], it means the linked and linking flags are in the
  * same module.
  */
-internal data class FlagLink(val moduleName: String, val flagName: String)
+internal data class FlagLink(val packageName: String, val flagName: String)


### PR DESCRIPTION
Flags that exist in other modules can be linked by `module-name:flag-name`, and for this purpose, there is logic to get the package name from the module name.
It uses `Task.getProject()`, but it'll be deprecated (only for task phase) and it cannot be used from Gradle 9.0.
Therefore, to avoid having to subtract the package name from the module name, the specification of the link notation should be changed so that the package name is directly described.

### Breaking Changes

Link type notation is changed as following:

**AS-IS**

```
module-name:flag_name
```

**TO-BE**

```
package.name:flag_name
```
