### PR TITLE
Support multiple feature flag files as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We may define flag phases as follows, for example.
 - `DEBUG`: Enabled when the build type is `debug`.
 - `RELEASE`: Enabled when the build type is `debug` or `release`.
 
-The following code is actuall configuration example.
+The following code is actual configuration example.
 
 ```build.gradle.kts
 featureFlag {
@@ -62,7 +62,7 @@ featureFlag {
 }
 ```
 
-Definition of each property is as follows. 
+Definition of each property is as follows.
 
 - `sourceFiles`: A set of feature flag property `File`s to read.
 - `packageName`: (Optional) A package name of generated `FeatureFlag` class. If this is not set, packageName will be set from `namespace` of Android Gradle Plugin
@@ -90,7 +90,7 @@ FLAG_4 = packageName:FLAG_A # Delegates flag enability to `FLAG_A` in module whi
 OVERRIDABLE FLAG_5 = DEBUG  # Makes the flag modifiable at runtime.
 PRIVATE FLAG_6 = DEBUG      # Makes the flag not accessible from a flag property file in another module.
 LITERALIZE FLAG_7 = DEBUG   # Try to use a primitive boolean as the flag value.
- 
+
 # Property combination
 # Enabled if either of the following conditions satisfies
 # 1. Built in `DEBUG` phase.
@@ -143,4 +143,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-See [LICENSE](LICENSE) for more detail. 
+See [LICENSE](LICENSE) for more detail.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ The following code is actuall configuration example.
 
 ```build.gradle.kts
 featureFlag {
-    sourceFile = file("FEATURE_FLAG")
+    sourceFiles.setFrom(file("FEATURE_FLAG"))
+    // You can also specify multiple files as follows.
+    // sourceFiles.setFrom(files("FEATURE_FLAG", "FEATURE_FLAG_2"))
+
     packageName = "com.example.featureflag"
     phases = mapOf(
         "DEBUG" to setOf(buildType("debug")),
@@ -61,7 +64,7 @@ featureFlag {
 
 Definition of each property is as follows. 
 
-- `sourceFile`: A feature flag property `File` to read.
+- `sourceFiles`: A set of feature flag property `File`s to read.
 - `packageName`: (Optional) A package name of generated `FeatureFlag` class. If this is not set, packageName will be set from `namespace` of Android Gradle Plugin
 - `phases`: A list of pairs of phase and the corresponding build variants.
 - `releasePhaseSet`: Build variants to allow using primitive boolean values as flag values. An optimizer may inline flag values with the variants. `buildType` or `flavor` can be specified as a variant.

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
@@ -18,7 +18,7 @@ package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
 import org.gradle.api.Project
-import java.io.File
+import org.gradle.api.file.ConfigurableFileCollection
 
 /**
  * A Gradle extension to provide a feature flag file.
@@ -26,7 +26,8 @@ import java.io.File
  * **Note**: Keep this an open class because a proxy class is created by the gradle system.
  */
 open class FeatureFlagExtension(project: Project) {
-    var sourceFile: File = project.rootDir.resolve(DEFAULT_FEATURE_FLAG_PROPERTY_FILE_NAME)
+    val sourceFiles: ConfigurableFileCollection =
+        project.files(project.rootDir.resolve(DEFAULT_FEATURE_FLAG_PROPERTY_FILE_NAME))
     var phases: Map<String, Set<BuildVariant.Element>> = mapOf()
     var releasePhaseSet: Set<BuildVariant.Element> = setOf()
     var packageName: String = ""

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -29,7 +29,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.register
-import java.io.File
 import java.util.Locale
 
 /**
@@ -84,9 +83,6 @@ class FeatureFlagPlugin : Plugin<Project> {
         extension: FeatureFlagExtension,
         versionName: String
     ) {
-        val localSourceFile = extension.sourceFile.takeIf(File::exists)
-            ?: throw RuntimeException("Missing `sourceFile` option or file isn't exist")
-
         val packageNameProvider = extension.packageName.takeIf(String::isNotEmpty)
             ?.let { packageName -> project.provider { packageName } }
             ?: variant.namespace
@@ -107,7 +103,7 @@ class FeatureFlagPlugin : Plugin<Project> {
             notCompatibleWithConfigurationCache(
                 "Requires Project instance to resolve build variants during task execution."
             )
-            sourceFile = localSourceFile
+            sourceFiles = extension.sourceFiles
             packageName.set(packageNameProvider)
             phaseMap = getPhaseMap(extension.phases, currentBuildVariant)
             isReleaseVariant = extension.releasePhaseSet.any(currentBuildVariant::includes)

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -25,18 +25,18 @@ import com.linecorp.android.featureflag.model.BuildEnvironment
 import com.linecorp.android.featureflag.model.FeatureFlagData
 import com.linecorp.android.featureflag.model.ForciblyOverriddenFeatureFlags
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import com.github.zafarkhaja.semver.Version
 import com.linecorp.android.featureflag.model.FeatureFlagEntry
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 
 /**
@@ -45,9 +45,9 @@ import org.gradle.api.provider.Property
 @CacheableTask
 abstract class FeatureFlagTask : DefaultTask() {
 
-    @get:InputFile
+    @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal abstract var sourceFile: File
+    internal abstract var sourceFiles: FileCollection
 
     @get:OutputDirectory
     internal abstract val outputDirectory: DirectoryProperty
@@ -96,7 +96,9 @@ abstract class FeatureFlagTask : DefaultTask() {
             Version.valueOf(applicationVersionName),
             currentUserName
         )
-        val entries = sourceFile.useLines(block = FeatureFlagFileTokenizer::parse)
+        val entries = sourceFiles
+            .map { it.useLines(block = FeatureFlagFileTokenizer::parse) }
+            .flatten()
         val featureFlags = entries.map {
             convertToFeatureFlagData(
                 it,

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -23,7 +23,6 @@ import com.linecorp.android.featureflag.loader.FeatureFlagSelectorParser
 import com.linecorp.android.featureflag.loader.FeatureFlagValueOptimizer
 import com.linecorp.android.featureflag.model.BuildEnvironment
 import com.linecorp.android.featureflag.model.FeatureFlagData
-import com.linecorp.android.featureflag.model.FeatureFlagProperties
 import com.linecorp.android.featureflag.model.ForciblyOverriddenFeatureFlags
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
@@ -36,6 +35,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import com.github.zafarkhaja.semver.Version
+import com.linecorp.android.featureflag.model.FeatureFlagEntry
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 
@@ -96,8 +96,8 @@ abstract class FeatureFlagTask : DefaultTask() {
             Version.valueOf(applicationVersionName),
             currentUserName
         )
-        val properties = sourceFile.useLines(block = FeatureFlagFileTokenizer::parse)
-        val featureFlags = properties.entries.map {
+        val entries = sourceFile.useLines(block = FeatureFlagFileTokenizer::parse)
+        val featureFlags = entries.map {
             convertToFeatureFlagData(
                 it,
                 buildEnvironment,
@@ -115,7 +115,7 @@ abstract class FeatureFlagTask : DefaultTask() {
     }
 
     private fun convertToFeatureFlagData(
-        entry: FeatureFlagProperties.Entry,
+        entry: FeatureFlagEntry,
         buildEnvironment: BuildEnvironment,
         forciblyEnabledFlags: Set<String>,
         forciblyDisabledFlags: Set<String>

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizer.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizer.kt
@@ -17,7 +17,7 @@
 package com.linecorp.android.featureflag.loader
 
 import com.linecorp.android.featureflag.loader.FeatureFlagFileTokenizer.parse
-import com.linecorp.android.featureflag.model.FeatureFlagProperties
+import com.linecorp.android.featureflag.model.FeatureFlagEntry
 
 /**
  * A string tokenizer for raw string lines of feature flag properties.
@@ -48,26 +48,22 @@ internal object FeatureFlagFileTokenizer {
      *
      * If the given sequence has a malformed line, this throws [IllegalArgumentException].
      */
-    fun parse(lines: Sequence<String>): FeatureFlagProperties =
-        FeatureFlagProperties(loadRawFeatureFlagEntries(lines))
-
-    private fun loadRawFeatureFlagEntries(
-        lines: Sequence<String>
-    ): List<FeatureFlagProperties.Entry> = lines
-        .map(::trimComment)
-        .filterNot(String::isBlank)
-        .map(::parseToRawFeatureFlagEntry)
-        .toList()
+    fun parse(lines: Sequence<String>): List<FeatureFlagEntry> =
+        lines
+            .map(::trimComment)
+            .filterNot(String::isBlank)
+            .map(::parseToRawFeatureFlagEntry)
+            .toList()
 
     private fun trimComment(line: String): String = line.split(COMMENT_MARKER)[0]
 
-    private fun parseToRawFeatureFlagEntry(line: String): FeatureFlagProperties.Entry {
+    private fun parseToRawFeatureFlagEntry(line: String): FeatureFlagEntry {
         val groupValues = FLAG_ENTRY_REGEX.find(line)?.groupValues
 
         require(groupValues != null && groupValues.size == 4) { "Couldn't parse a line: $line" }
         check(groupValues[3].isNotBlank()) { "Value mustn't be empty: $line" }
 
-        return FeatureFlagProperties.Entry(
+        return FeatureFlagEntry(
             name = groupValues[2].trim(),
             value = groupValues[3].trim(),
             option = groupValues[1].trim()

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/FeatureFlagEntry.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/FeatureFlagEntry.kt
@@ -17,11 +17,7 @@
 package com.linecorp.android.featureflag.model
 
 /**
- * A list of feature flag entries, where each entry is a tuple of raw strings: a feature name
- * string, value string, and option string.
+ * A entry of feature flag which is a tuple of raw strings: a feature name string, value string,
+ * and option string.
  */
-internal data class FeatureFlagProperties(
-    val entries: List<Entry>
-) {
-    data class Entry(val name: String, val value: String, val option: String)
-}
+internal data class FeatureFlagEntry(val name: String, val value: String, val option: String)

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
@@ -20,6 +20,7 @@ import com.linecorp.android.featureflag.model.BuildVariant
 import io.mockk.every
 import io.mockk.mockk
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.io.File
@@ -27,8 +28,10 @@ import kotlin.test.assertEquals
 
 object FeatureFlagExtensionTest : Spek({
     describe("public functions return correct values") {
+        val mockedSourceFiles = mockk<ConfigurableFileCollection>()
         val project: Project = mockk {
             every { rootDir } returns File("/tmp/")
+            every { files(File("/tmp/FEATURE_FLAG")) } returns mockedSourceFiles
         }
         val extension by memoized {
             FeatureFlagExtension(

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
@@ -16,8 +16,7 @@
 
 package com.linecorp.android.featureflag.loader
 
-import com.linecorp.android.featureflag.model.FeatureFlagProperties
-import com.linecorp.android.featureflag.model.FeatureFlagProperties.Entry
+import com.linecorp.android.featureflag.model.FeatureFlagEntry
 import com.linecorp.android.featureflag.utils.assertFailureMessage
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -37,46 +36,43 @@ object FeatureFlagFileTokenizerTest : Spek({
         return File(url.toURI()).bufferedReader().lineSequence()
     }
 
-    fun createFeatureFlagProperties(vararg entries: Entry): FeatureFlagProperties =
-        FeatureFlagProperties(entries.toList())
-
     describe("Parsed result is correct") {
         it("with options") {
             assertEquals(
-                createFeatureFlagProperties(
-                    Entry("FLAG_1", "VALUE", "OPTION"),
-                    Entry("FLAG_2", "VALUE", "OPTION"),
-                    Entry("FLAG_3", "VALUE", "OPTION1 OPTION2"),
-                    Entry("FLAG_4", "VALUE", "OPTION1  OPTION2")
+                listOf(
+                    FeatureFlagEntry("FLAG_1", "VALUE", "OPTION"),
+                    FeatureFlagEntry("FLAG_2", "VALUE", "OPTION"),
+                    FeatureFlagEntry("FLAG_3", "VALUE", "OPTION1 OPTION2"),
+                    FeatureFlagEntry("FLAG_4", "VALUE", "OPTION1  OPTION2")
                 ),
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_OPTION"))
             )
         }
         it("with name") {
             assertEquals(
-                createFeatureFlagProperties(
-                    Entry("FLAG_1", "VALUE", ""),
-                    Entry("FLAG_2", "VALUE", ""),
-                    Entry("FLAG_3", "VALUE", "")
+                listOf(
+                    FeatureFlagEntry("FLAG_1", "VALUE", ""),
+                    FeatureFlagEntry("FLAG_2", "VALUE", ""),
+                    FeatureFlagEntry("FLAG_3", "VALUE", "")
                 ),
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_NAME"))
             )
         }
         it("with value") {
             assertEquals(
-                createFeatureFlagProperties(
-                    Entry("FLAG_1", "VALUE", ""),
-                    Entry("FLAG_2", "VALUE", ""),
-                    Entry("FLAG_3", "VALUE VALUE", ""),
-                    Entry("FLAG_4", "VALUE", ""),
-                    Entry("FLAG_5", "VALUE=VALUE", "")
+                listOf(
+                    FeatureFlagEntry("FLAG_1", "VALUE", ""),
+                    FeatureFlagEntry("FLAG_2", "VALUE", ""),
+                    FeatureFlagEntry("FLAG_3", "VALUE VALUE", ""),
+                    FeatureFlagEntry("FLAG_4", "VALUE", ""),
+                    FeatureFlagEntry("FLAG_5", "VALUE=VALUE", "")
                 ),
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_VALUE"))
             )
         }
         it("with empty") {
             assertEquals(
-                createFeatureFlagProperties(),
+                emptyList(),
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_EMPTY"))
             )
         }


### PR DESCRIPTION
Supports multiple feature flag files as input.
When a single flag file is edited by a large number of people, there are many opportunities for conflicts to occur.
To reduce this, it is possible to split a flag file at an appropriate granularity.

### Breaking Changes

Change `sourceFile` to `sourceFiles` and change type to `ConfigurableFileCollection`.

**AS-IS**

```
sourceFile = file("FEATURE_FLAG")
```

**TO-BE**

```
sourceFiles.setFrom(file("FEATURE_FLAG"))
sourceFiles.setFrom(files("FEATURE_FLAG", "FEATURE_FLAG_2"))
```
