### PR TITLE
Fix support version notation of intellij plugin

### DIFF
--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -80,7 +80,8 @@ intellijPlatform {
         }
 
         ideaVersion {
-            sinceBuild = "241.18034" // Koala | 2024.1.1 Patch 1
+            // https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html
+            sinceBuild = "241"
             untilBuild = provider { null } // Accept all versions since `sinceBuild`.
         }
     }

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -81,7 +81,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = "241.18034" // Koala | 2024.1.1 Patch 1
-            untilBuild = null
+            untilBuild = provider { null } // Accept all versions since `sinceBuild`.
         }
     }
 

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
@@ -103,7 +104,10 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            // Only on GitHub CI, verify for 2024.2 fails because there is no java plugin. as with
+            // the `intellijPlatform` item, the version is temporarily fixed because it seems to be
+            // unstable above 2024.2 now.
+            ide(IntelliJPlatformType.AndroidStudio, "2024.1.2.13")
         }
     }
 


### PR DESCRIPTION
There was a mistake in the IntelliJ version notation supported by the IntelliJ plugin, which only supported `241.*` versions above `241.18034`.
The notation has been corrected to support all IntelliJ versions from version 241 and above.