### PR TITLE
Implement simpleified version parser

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ featureFlag {
         "RELEASE" to setOf(buildType("debug"), buildType("release"))
     )
     releasePhaseSet = setOf(buildType("release"))
+    versionNotation = VersionNotation.SEM_VER
 }
 ```
 
@@ -69,6 +70,9 @@ Definition of each property is as follows.
 - `phases`: A list of pairs of phase and the corresponding build variants.
 - `releasePhaseSet`: Build variants to allow using primitive boolean values as flag values. An optimizer may inline flag values with the variants. `buildType` or `flavor` can be specified as a variant.
 - `versionName`: (Optional) A version name which can override application version name.
+- `versionNotation`: (Optional) A value indicating how to interpret and compare version strings.
+    - `SEM_VER`: Using [Semantic Versioning 2.0.0](https://semver.org/).
+    - `SIMPLE`: Compare the numbers separated by dots from left to right.
 
    Also, this property can be assigned for library module since Android Gradle Plugin 7.0 or higher.
 

--- a/feature-flag/build.gradle.kts
+++ b/feature-flag/build.gradle.kts
@@ -1,7 +1,9 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
+    `java-library`
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.gradle.publish)
     `java-gradle-plugin`
@@ -27,6 +29,17 @@ gradlePlugin {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 ktlint {
     reporters {
         reporter(ReporterType.PLAIN)
@@ -35,9 +48,7 @@ ktlint {
 }
 
 tasks.withType(Test::class.java) {
-    useJUnitPlatform {
-        includeEngines("spek2")
-    }
+    useJUnitPlatform()
 }
 
 fun isStable(version: String): Boolean {
@@ -59,9 +70,10 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.mockk)
-    testImplementation(libs.spek2.dsl.jvm)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.framework.engine)
+    testImplementation(libs.kotest.assertions.core)
     testRuntimeOnly(libs.kotlin.reflect)
-    testRuntimeOnly(libs.spek2.runner.junit5)
 }
 
 publishing {

--- a/feature-flag/build.gradle.kts
+++ b/feature-flag/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    `kotlin-dsl`
     alias(libs.plugins.gradle.publish)
     `java-gradle-plugin`
     alias(libs.plugins.ktlint.gradle)

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagExtension.kt
@@ -17,6 +17,7 @@
 package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
+import com.linecorp.android.featureflag.model.VersionNotation
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 
@@ -32,6 +33,7 @@ open class FeatureFlagExtension(project: Project) {
     var releasePhaseSet: Set<BuildVariant.Element> = setOf()
     var packageName: String = ""
     var versionName: String = ""
+    var versionNotation: VersionNotation = VersionNotation.SEM_VER
 
     fun buildType(name: String): BuildVariant.Element = BuildVariant.Element.BuildType(name)
 

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -28,8 +28,6 @@ import com.linecorp.android.featureflag.model.ForciblyOverriddenFeatureFlags
 import java.util.Locale
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.register
 
 /**
  * A gradle plugin adding a task to create a feature flag Java file from a property file.
@@ -38,7 +36,11 @@ import org.gradle.kotlin.dsl.register
 class FeatureFlagPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-        val extension = project.extensions.create<FeatureFlagExtension>("featureFlag", project)
+        val extension = project.extensions.create(
+            "featureFlag",
+            FeatureFlagExtension::class.java,
+            project
+        )
 
         project.plugins.withType(AppPlugin::class.java) {
             project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
@@ -99,14 +101,14 @@ class FeatureFlagPlugin : Plugin<Project> {
             if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
         }
         val taskName = "generate${capitalizedVariantName}FeatureFlag"
-        val taskProvider = project.tasks.register<FeatureFlagTask>(taskName) {
-            sourceFiles = extension.sourceFiles
-            packageName.set(packageNameProvider)
-            phaseMap = getPhaseMap(extension.phases, currentBuildVariant)
-            isReleaseVariant = extension.releasePhaseSet.any(currentBuildVariant::includes)
-            applicationVersionName = versionName
-            currentUserName = System.getProperty("user.name")
-            forciblyOverriddenFeatureFlags = ForciblyOverriddenFeatureFlags.parse(project)
+        val taskProvider = project.tasks.register(taskName, FeatureFlagTask::class.java) {
+            it.sourceFiles = extension.sourceFiles
+            it.packageName.set(packageNameProvider)
+            it.phaseMap = getPhaseMap(extension.phases, currentBuildVariant)
+            it.isReleaseVariant = extension.releasePhaseSet.any(currentBuildVariant::includes)
+            it.applicationVersionName = versionName
+            it.currentUserName = System.getProperty("user.name")
+            it.forciblyOverriddenFeatureFlags = ForciblyOverriddenFeatureFlags.parse(project)
         }
         variant.sources.java
             ?.addGeneratedSourceDirectory(taskProvider, FeatureFlagTask::outputDirectory)

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagPlugin.kt
@@ -107,6 +107,7 @@ class FeatureFlagPlugin : Plugin<Project> {
             it.phaseMap = getPhaseMap(extension.phases, currentBuildVariant)
             it.isReleaseVariant = extension.releasePhaseSet.any(currentBuildVariant::includes)
             it.applicationVersionName = versionName
+            it.versionNotation = extension.versionNotation
             it.currentUserName = System.getProperty("user.name")
             it.forciblyOverriddenFeatureFlags = ForciblyOverriddenFeatureFlags.parse(project)
         }

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/FeatureFlagTask.kt
@@ -16,16 +16,17 @@
 
 package com.linecorp.android.featureflag
 
-import com.github.zafarkhaja.semver.Version
 import com.linecorp.android.featureflag.loader.FeatureFlagFileTokenizer
 import com.linecorp.android.featureflag.loader.FeatureFlagOptionParser
 import com.linecorp.android.featureflag.loader.FeatureFlagSelectorEvaluator
 import com.linecorp.android.featureflag.loader.FeatureFlagSelectorParser
 import com.linecorp.android.featureflag.loader.FeatureFlagValueOptimizer
+import com.linecorp.android.featureflag.model.ApplicationVersion
 import com.linecorp.android.featureflag.model.BuildEnvironment
 import com.linecorp.android.featureflag.model.FeatureFlagData
 import com.linecorp.android.featureflag.model.FeatureFlagEntry
 import com.linecorp.android.featureflag.model.ForciblyOverriddenFeatureFlags
+import com.linecorp.android.featureflag.model.VersionNotation
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -74,6 +75,9 @@ abstract class FeatureFlagTask : DefaultTask() {
     internal abstract var applicationVersionName: String
 
     @get:Input
+    internal abstract var versionNotation: VersionNotation
+
+    @get:Input
     internal abstract var currentUserName: String
 
     @get:Internal
@@ -94,7 +98,7 @@ abstract class FeatureFlagTask : DefaultTask() {
         outputDirectoryFile.deleteRecursively()
         val buildEnvironment = BuildEnvironment(
             phaseMap,
-            Version.valueOf(applicationVersionName),
+            ApplicationVersion.from(applicationVersionName, versionNotation),
             currentUserName
         )
         val entries = sourceFiles

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluator.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluator.kt
@@ -16,7 +16,6 @@
 
 package com.linecorp.android.featureflag.loader
 
-import com.github.zafarkhaja.semver.Version
 import com.linecorp.android.featureflag.loader.FeatureFlagSelectorEvaluator.evaluate
 import com.linecorp.android.featureflag.model.BuildEnvironment
 import com.linecorp.android.featureflag.model.DisjunctionNormalForm.Conjunction
@@ -81,9 +80,8 @@ internal object FeatureFlagSelectorEvaluator {
         is FeatureFlagElement.Phase -> Constant(isEnabledPhase(element, buildEnvironment.phasesMap))
         is FeatureFlagElement.User -> Constant(isEnabledUser(element, buildEnvironment.userName))
         is FeatureFlagElement.Link -> Variable(element.link)
-        is FeatureFlagElement.Version -> Constant(
-            isEnabledVersion(element, buildEnvironment.applicationVersion)
-        )
+        is FeatureFlagElement.Version ->
+            Constant(buildEnvironment.applicationVersion.isHigherOrEqualThan(element.version))
     }
 
     private fun isEnabledPhase(
@@ -95,9 +93,4 @@ internal object FeatureFlagSelectorEvaluator {
         element: FeatureFlagElement.User,
         userName: String
     ): Boolean = element.name == userName
-
-    private fun isEnabledVersion(
-        element: FeatureFlagElement.Version,
-        applicationVersion: Version
-    ): Boolean = Version.valueOf(element.version) <= applicationVersion
 }

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/ApplicationVersion.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/ApplicationVersion.kt
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.linecorp.android.featureflag.model
+
+import org.jetbrains.annotations.VisibleForTesting
+import com.github.zafarkhaja.semver.Version as SemVerImpl
+
+/**
+ * An interface representing the application version and its comparison method.
+ */
+internal sealed interface ApplicationVersion {
+
+    fun isHigherOrEqualThan(versionString: String): Boolean
+
+    /**
+     * An application version in Semantic Versioning (SemVer) notation.
+     */
+    class SemVer(@VisibleForTesting internal val version: SemVerImpl) :
+        ApplicationVersion,
+        Comparable<SemVer> {
+
+        override fun isHigherOrEqualThan(versionString: String): Boolean =
+            this >= from(versionString)
+
+        override fun compareTo(other: SemVer): Int = version.compareTo(other.version)
+
+        companion object {
+            fun from(versionString: String): SemVer = SemVer(SemVerImpl.parse(versionString))
+        }
+    }
+
+    companion object {
+        fun from(versionString: String, versionNotation: VersionNotation): ApplicationVersion =
+            when (versionNotation) {
+                VersionNotation.SEM_VER -> SemVer.from(versionString)
+            }
+    }
+}

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/ApplicationVersion.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/ApplicationVersion.kt
@@ -43,10 +43,57 @@ internal sealed interface ApplicationVersion {
         }
     }
 
+    /**
+     * An application version in simple dot-separated numeric values.
+     * See [VersionNotation.SIMPLE] for details.
+     */
+    class Simple(@VisibleForTesting internal val versionNumberList: List<Int>) :
+        ApplicationVersion,
+        Comparable<Simple> {
+
+        override fun isHigherOrEqualThan(versionString: String): Boolean =
+            this >= from(versionString)
+
+        override fun compareTo(other: Simple): Int {
+            if (other.versionNumberList.size != versionNumberList.size) {
+                throw IllegalArgumentException(
+                    "Incompatible version format: " +
+                        "${versionNumberList.joinToString(".")} and " +
+                        other.versionNumberList.joinToString(".")
+                )
+            }
+            val size = versionNumberList.size
+            for (i in 0 until size) {
+                val thisNumber = versionNumberList[i]
+                val otherNumber = other.versionNumberList[i]
+                if (thisNumber != otherNumber) {
+                    return thisNumber - otherNumber
+                }
+            }
+            return 0
+        }
+
+        companion object {
+            fun from(versionString: String): Simple {
+                if (versionString.isBlank()) {
+                    throw IllegalArgumentException("Input value is empty")
+                }
+                val versionNumberList = versionString
+                    .split(".")
+                    .map {
+                        it.toIntOrNull()?.takeIf { it >= 0 }
+                            ?: throw IllegalArgumentException("Invalid version: $versionString")
+                    }
+                return Simple(versionNumberList)
+            }
+        }
+    }
+
     companion object {
         fun from(versionString: String, versionNotation: VersionNotation): ApplicationVersion =
             when (versionNotation) {
                 VersionNotation.SEM_VER -> SemVer.from(versionString)
+                VersionNotation.SIMPLE -> Simple.from(versionString)
             }
     }
 }

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/BuildEnvironment.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/BuildEnvironment.kt
@@ -16,8 +16,6 @@
 
 package com.linecorp.android.featureflag.model
 
-import com.github.zafarkhaja.semver.Version
-
 /**
  * A model class of the current build information: build phase, version, and user.
  */
@@ -34,7 +32,7 @@ internal class BuildEnvironment(
     /**
      * A version of this module defined in the build script.
      */
-    val applicationVersion: Version,
+    val applicationVersion: ApplicationVersion,
     /**
      * An account name of the current task executor.
      */

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/VersionNotation.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/VersionNotation.kt
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.linecorp.android.featureflag.model
+
+/**
+ * An enum of version notation.
+ */
+enum class VersionNotation {
+    /**
+     * Semantic Versioning (SemVer) notation.
+     */
+    SEM_VER,
+}

--- a/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/VersionNotation.kt
+++ b/feature-flag/src/main/kotlin/com/linecorp/android/featureflag/model/VersionNotation.kt
@@ -24,4 +24,18 @@ enum class VersionNotation {
      * Semantic Versioning (SemVer) notation.
      */
     SEM_VER,
+
+    /**
+     * Version notation using simple dot-separated numeric values, and compare the numbers separated
+     * by dots from left to right.
+     * The number of dots must be the same for each version being compared.
+     * Generally, it must match the following regex:
+     *
+     * ```
+     * (\d+)(\.(\d+))*
+     * ```
+     *
+     * It is best to use this when the version may contain numbers starting from zero, as in CalVer.
+     */
+    SIMPLE
 }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
@@ -18,10 +18,10 @@ package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import java.io.File
-import kotlin.test.assertEquals
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 
@@ -34,15 +34,9 @@ class FeatureFlagExtensionTest : FunSpec({
     val extension = FeatureFlagExtension(project)
 
     test("buildType") {
-        assertEquals(
-            BuildVariant.Element.BuildType("release"),
-            extension.buildType("release")
-        )
+        extension.buildType("release") shouldBe BuildVariant.Element.BuildType("release")
     }
     test("flavor") {
-        assertEquals(
-            BuildVariant.Element.Flavor("production"),
-            extension.flavor("production")
-        )
+        extension.flavor("release") shouldBe BuildVariant.Element.Flavor("release")
     }
 })

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
@@ -17,39 +17,32 @@
 package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
+import io.kotest.core.spec.style.FunSpec
 import io.mockk.every
 import io.mockk.mockk
 import java.io.File
 import kotlin.test.assertEquals
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
-object FeatureFlagExtensionTest : Spek({
-    describe("public functions return correct values") {
-        val mockedSourceFiles = mockk<ConfigurableFileCollection>()
-        val project: Project = mockk {
-            every { rootDir } returns File("/tmp/")
-            every { files(File("/tmp/FEATURE_FLAG")) } returns mockedSourceFiles
-        }
-        val extension by memoized {
-            FeatureFlagExtension(
-                project
-            )
-        }
+class FeatureFlagExtensionTest : FunSpec({
+    val mockedSourceFiles = mockk<ConfigurableFileCollection>()
+    val project: Project = mockk {
+        every { rootDir } returns File("/tmp/")
+        every { files(File("/tmp/FEATURE_FLAG")) } returns mockedSourceFiles
+    }
+    val extension = FeatureFlagExtension(project)
 
-        it("buildType") {
-            assertEquals(
-                BuildVariant.Element.BuildType("release"),
-                extension.buildType("release")
-            )
-        }
-        it("flavor") {
-            assertEquals(
-                BuildVariant.Element.Flavor("production"),
-                extension.flavor("production")
-            )
-        }
+    test("buildType") {
+        assertEquals(
+            BuildVariant.Element.BuildType("release"),
+            extension.buildType("release")
+        )
+    }
+    test("flavor") {
+        assertEquals(
+            BuildVariant.Element.Flavor("production"),
+            extension.flavor("production")
+        )
     }
 })

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagExtensionTest.kt
@@ -37,6 +37,6 @@ class FeatureFlagExtensionTest : FunSpec({
         extension.buildType("release") shouldBe BuildVariant.Element.BuildType("release")
     }
     test("flavor") {
-        extension.flavor("release") shouldBe BuildVariant.Element.Flavor("release")
+        extension.flavor("production") shouldBe BuildVariant.Element.Flavor("production")
     }
 })

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagPluginTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagPluginTest.kt
@@ -17,14 +17,13 @@
 package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
+import io.kotest.core.spec.style.FunSpec
 import kotlin.test.assertEquals
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 /**
  * Tests for [FeatureFlagPlugin].
  */
-object FeatureFlagPluginTest : Spek({
+class FeatureFlagPluginTest : FunSpec({
     val plugin = FeatureFlagPlugin()
 
     fun setOfBuildTypes(vararg buildTypeString: String): Set<BuildVariant.Element> =
@@ -39,7 +38,7 @@ object FeatureFlagPluginTest : Spek({
             productFlavorStrings.map { BuildVariant.Element.Flavor(it) }.toSet()
         )
 
-    describe("getPhaseMap") {
+    context("getPhaseMap") {
         context("returns correct value with buildType") {
             val phases = mapOf(
                 "DEV" to setOfBuildTypes("dev"),
@@ -47,7 +46,7 @@ object FeatureFlagPluginTest : Spek({
                 "RC" to setOfBuildTypes("rc", "beta", "dev"),
                 "RELEASE" to setOfBuildTypes("release", "rc", "beta", "dev")
             )
-            it("in DEV") {
+            test("in DEV") {
                 val expected = mapOf(
                     "DEV" to true,
                     "BETA" to true,
@@ -56,7 +55,7 @@ object FeatureFlagPluginTest : Spek({
                 )
                 assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("dev")))
             }
-            it("in BETA") {
+            test("in BETA") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to true,
@@ -65,7 +64,7 @@ object FeatureFlagPluginTest : Spek({
                 )
                 assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("beta")))
             }
-            it("in RC") {
+            test("in RC") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,
@@ -74,7 +73,7 @@ object FeatureFlagPluginTest : Spek({
                 )
                 assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("rc")))
             }
-            it("in RELEASE") {
+            test("in RELEASE") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,
@@ -83,7 +82,7 @@ object FeatureFlagPluginTest : Spek({
                 )
                 assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("release")))
             }
-            it("unknown phase") {
+            test("unknown phase") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,
@@ -100,7 +99,7 @@ object FeatureFlagPluginTest : Spek({
                 "RC" to setOfProductFlavors("rc", "beta", "dev"),
                 "RELEASE" to setOfProductFlavors("release", "rc", "beta", "dev")
             )
-            it("in DEV") {
+            test("in DEV") {
                 val expected = mapOf(
                     "DEV" to true,
                     "BETA" to true,
@@ -112,7 +111,7 @@ object FeatureFlagPluginTest : Spek({
                     plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "dev"))
                 )
             }
-            it("in BETA") {
+            test("in BETA") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to true,
@@ -124,7 +123,7 @@ object FeatureFlagPluginTest : Spek({
                     plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "beta"))
                 )
             }
-            it("in RC") {
+            test("in RC") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,
@@ -136,7 +135,7 @@ object FeatureFlagPluginTest : Spek({
                     plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "rc"))
                 )
             }
-            it("in RELEASE") {
+            test("in RELEASE") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,
@@ -148,7 +147,7 @@ object FeatureFlagPluginTest : Spek({
                     plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "release"))
                 )
             }
-            it("unknown phase") {
+            test("unknown phase") {
                 val expected = mapOf(
                     "DEV" to false,
                     "BETA" to false,

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagPluginTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/FeatureFlagPluginTest.kt
@@ -18,7 +18,7 @@ package com.linecorp.android.featureflag
 
 import com.linecorp.android.featureflag.model.BuildVariant
 import io.kotest.core.spec.style.FunSpec
-import kotlin.test.assertEquals
+import io.kotest.matchers.shouldBe
 
 /**
  * Tests for [FeatureFlagPlugin].
@@ -53,7 +53,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("dev")))
+                plugin.getPhaseMap(phases, buildVariantOf("dev")) shouldBe expected
             }
             test("in BETA") {
                 val expected = mapOf(
@@ -62,7 +62,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("beta")))
+                plugin.getPhaseMap(phases, buildVariantOf("beta")) shouldBe expected
             }
             test("in RC") {
                 val expected = mapOf(
@@ -71,7 +71,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("rc")))
+                plugin.getPhaseMap(phases, buildVariantOf("rc")) shouldBe expected
             }
             test("in RELEASE") {
                 val expected = mapOf(
@@ -80,7 +80,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to false,
                     "RELEASE" to true
                 )
-                assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("release")))
+                plugin.getPhaseMap(phases, buildVariantOf("release")) shouldBe expected
             }
             test("unknown phase") {
                 val expected = mapOf(
@@ -89,7 +89,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to false,
                     "RELEASE" to false
                 )
-                assertEquals(expected, plugin.getPhaseMap(phases, buildVariantOf("INVALID")))
+                plugin.getPhaseMap(phases, buildVariantOf("INVALID")) shouldBe expected
             }
         }
         context("returns correct value with flavor") {
@@ -106,10 +106,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(
-                    expected,
-                    plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "dev"))
-                )
+                plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "dev")) shouldBe expected
             }
             test("in BETA") {
                 val expected = mapOf(
@@ -118,10 +115,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(
-                    expected,
-                    plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "beta"))
-                )
+                plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "beta")) shouldBe expected
             }
             test("in RC") {
                 val expected = mapOf(
@@ -130,10 +124,7 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to true,
                     "RELEASE" to true
                 )
-                assertEquals(
-                    expected,
-                    plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "rc"))
-                )
+                plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "rc")) shouldBe expected
             }
             test("in RELEASE") {
                 val expected = mapOf(
@@ -142,10 +133,10 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to false,
                     "RELEASE" to true
                 )
-                assertEquals(
-                    expected,
-                    plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "release"))
-                )
+                plugin.getPhaseMap(
+                    phases,
+                    buildVariantOf("BUILD_TYPE", "release")
+                ) shouldBe expected
             }
             test("unknown phase") {
                 val expected = mapOf(
@@ -154,10 +145,10 @@ class FeatureFlagPluginTest : FunSpec({
                     "RC" to false,
                     "RELEASE" to false
                 )
-                assertEquals(
-                    expected,
-                    plugin.getPhaseMap(phases, buildVariantOf("BUILD_TYPE", "INVALID"))
-                )
+                plugin.getPhaseMap(
+                    phases,
+                    buildVariantOf("BUILD_TYPE", "INVALID")
+                ) shouldBe expected
             }
         }
     }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
@@ -18,16 +18,15 @@ package com.linecorp.android.featureflag.loader
 
 import com.linecorp.android.featureflag.model.FeatureFlagEntry
 import com.linecorp.android.featureflag.utils.assertFailureMessage
+import io.kotest.core.spec.style.FunSpec
 import java.io.File
 import kotlin.test.assertEquals
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 /**
  * Tests for [FeatureFlagFileTokenizer].
  * All the text resources are in "tests/FeatureFlagFileTokenizerTest/" directory.
  */
-object FeatureFlagFileTokenizerTest : Spek({
+class FeatureFlagFileTokenizerTest : FunSpec({
 
     fun loadSequenceFromFile(name: String): Sequence<String> {
         val url = checkNotNull(
@@ -36,8 +35,8 @@ object FeatureFlagFileTokenizerTest : Spek({
         return File(url.toURI()).bufferedReader().lineSequence()
     }
 
-    describe("Parsed result is correct") {
-        it("with options") {
+    context("Parsed result is correct") {
+        test("with options") {
             assertEquals(
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", "OPTION"),
@@ -48,7 +47,7 @@ object FeatureFlagFileTokenizerTest : Spek({
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_OPTION"))
             )
         }
-        it("with name") {
+        test("with name") {
             assertEquals(
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", ""),
@@ -58,7 +57,7 @@ object FeatureFlagFileTokenizerTest : Spek({
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_NAME"))
             )
         }
-        it("with value") {
+        test("with value") {
             assertEquals(
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", ""),
@@ -70,7 +69,7 @@ object FeatureFlagFileTokenizerTest : Spek({
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_VALUE"))
             )
         }
-        it("with empty") {
+        test("with empty") {
             assertEquals(
                 emptyList(),
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_EMPTY"))
@@ -78,28 +77,28 @@ object FeatureFlagFileTokenizerTest : Spek({
         }
     }
 
-    describe("Parsing is failed") {
-        it("if a line has't key-value pair") {
+    context("Parsing is failed") {
+        test("if a line has't key-value pair") {
             assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: INVALID_LINE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_NO_KEY_VALUE"))
             }
         }
-        it("if a key is empty") {
+        test("if a key is empty") {
             assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: =VALUE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_EMPTY_KEY"))
             }
         }
-        it("if a key is blank") {
+        test("if a key is blank") {
             assertFailureMessage<IllegalArgumentException>("Couldn't parse a line:  =VALUE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_BLANK_KEY"))
             }
         }
-        it("if a value is empty") {
+        test("if a value is empty") {
             assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: KEY=") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_EMPTY_VALUE"))
             }
         }
-        it("if a value is blank") {
+        test("if a value is blank") {
             assertFailureMessage<IllegalStateException>("Value mustn't be empty: KEY= ") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_BLANK_VALUE"))
             }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
@@ -17,10 +17,10 @@
 package com.linecorp.android.featureflag.loader
 
 import com.linecorp.android.featureflag.model.FeatureFlagEntry
-import com.linecorp.android.featureflag.utils.assertFailureMessage
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import java.io.File
-import kotlin.test.assertEquals
 
 /**
  * Tests for [FeatureFlagFileTokenizer].
@@ -37,69 +37,61 @@ class FeatureFlagFileTokenizerTest : FunSpec({
 
     context("Parsed result is correct") {
         test("with options") {
-            assertEquals(
+            FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_OPTION")) shouldBe
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", "OPTION"),
                     FeatureFlagEntry("FLAG_2", "VALUE", "OPTION"),
                     FeatureFlagEntry("FLAG_3", "VALUE", "OPTION1 OPTION2"),
                     FeatureFlagEntry("FLAG_4", "VALUE", "OPTION1  OPTION2")
-                ),
-                FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_OPTION"))
-            )
+                )
         }
         test("with name") {
-            assertEquals(
+            FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_NAME")) shouldBe
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", ""),
                     FeatureFlagEntry("FLAG_2", "VALUE", ""),
                     FeatureFlagEntry("FLAG_3", "VALUE", "")
-                ),
-                FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_NAME"))
-            )
+                )
         }
         test("with value") {
-            assertEquals(
+            FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_VALUE")) shouldBe
                 listOf(
                     FeatureFlagEntry("FLAG_1", "VALUE", ""),
                     FeatureFlagEntry("FLAG_2", "VALUE", ""),
                     FeatureFlagEntry("FLAG_3", "VALUE VALUE", ""),
                     FeatureFlagEntry("FLAG_4", "VALUE", ""),
                     FeatureFlagEntry("FLAG_5", "VALUE=VALUE", "")
-                ),
-                FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_VALUE"))
-            )
+                )
         }
         test("with empty") {
-            assertEquals(
-                emptyList(),
-                FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_EMPTY"))
-            )
+            FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_VALID_EMPTY")) shouldBe
+                emptyList()
         }
     }
 
     context("Parsing is failed") {
         test("if a line has't key-value pair") {
-            assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: INVALID_LINE") {
+            shouldThrowWithMessage<IllegalArgumentException>("Couldn't parse a line: INVALID_LINE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_NO_KEY_VALUE"))
             }
         }
         test("if a key is empty") {
-            assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: =VALUE") {
+            shouldThrowWithMessage<IllegalArgumentException>("Couldn't parse a line: =VALUE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_EMPTY_KEY"))
             }
         }
         test("if a key is blank") {
-            assertFailureMessage<IllegalArgumentException>("Couldn't parse a line:  =VALUE") {
+            shouldThrowWithMessage<IllegalArgumentException>("Couldn't parse a line:  =VALUE") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_BLANK_KEY"))
             }
         }
         test("if a value is empty") {
-            assertFailureMessage<IllegalArgumentException>("Couldn't parse a line: KEY=") {
+            shouldThrowWithMessage<IllegalArgumentException>("Couldn't parse a line: KEY=") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_EMPTY_VALUE"))
             }
         }
         test("if a value is blank") {
-            assertFailureMessage<IllegalStateException>("Value mustn't be empty: KEY= ") {
+            shouldThrowWithMessage<IllegalStateException>("Value mustn't be empty: KEY= ") {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_BLANK_VALUE"))
             }
         }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagFileTokenizerTest.kt
@@ -71,7 +71,9 @@ class FeatureFlagFileTokenizerTest : FunSpec({
 
     context("Parsing is failed") {
         test("if a line has't key-value pair") {
-            shouldThrowWithMessage<IllegalArgumentException>("Couldn't parse a line: INVALID_LINE") {
+            shouldThrowWithMessage<IllegalArgumentException>(
+                "Couldn't parse a line: INVALID_LINE"
+            ) {
                 FeatureFlagFileTokenizer.parse(loadSequenceFromFile("FLAG_INVALID_NO_KEY_VALUE"))
             }
         }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagOptionParserTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagOptionParserTest.kt
@@ -21,16 +21,15 @@ import com.linecorp.android.featureflag.model.FeatureFlagOption.DEPRECATED
 import com.linecorp.android.featureflag.model.FeatureFlagOption.OVERRIDABLE
 import com.linecorp.android.featureflag.model.FeatureFlagOption.PRIVATE
 import com.linecorp.android.featureflag.utils.assertFailureMessage
+import io.kotest.core.spec.style.FunSpec
 import java.io.File
 import kotlin.test.assertEquals
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 /**
  * Tests for [FeatureFlagOptionParser].
  * All the text resources are in "tests/FeatureFlagOptionParser/" directory.
  */
-object FeatureFlagOptionParserTest : Spek({
+class FeatureFlagOptionParserTest : FunSpec({
     fun loadLinesFromFile(name: String): List<String> {
         val url = checkNotNull(
             javaClass.classLoader.getResource("tests/FeatureFlagOptionParserTest/$name")
@@ -38,8 +37,8 @@ object FeatureFlagOptionParserTest : Spek({
         return File(url.toURI()).bufferedReader().lineSequence().toList()
     }
 
-    describe("Precondition") {
-        it("A reverse map of Option enum is sufficient") {
+    context("Precondition") {
+        test("A reverse map of Option enum is sufficient") {
             val actualEnums = FeatureFlagOption.values().toList()
             val reverseMapContainsEnums = FeatureFlagOptionParser.OPTION_MAPPING.values
 
@@ -49,7 +48,7 @@ object FeatureFlagOptionParserTest : Spek({
         }
     }
 
-    describe("Parsed result is correct") {
+    context("Parsed result is correct") {
         context("with normal case") {
             val expectedResults = listOf(
                 setOf(PRIVATE),
@@ -61,14 +60,14 @@ object FeatureFlagOptionParserTest : Spek({
             val testCases = loadLinesFromFile("OPTION_VALID_NORMAL")
 
             testCases.forEachIndexed { index, testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
                 }
             }
         }
 
         context("with empty") {
-            it("Empty option") {
+            test("Empty option") {
                 assertEquals(emptySet<FeatureFlagOption>(), FeatureFlagOptionParser.parse(""))
             }
         }
@@ -87,7 +86,7 @@ object FeatureFlagOptionParserTest : Spek({
             val testCases = loadLinesFromFile("OPTION_VALID_DUPLICATED")
 
             testCases.forEachIndexed { index, testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
                 }
             }
@@ -105,15 +104,15 @@ object FeatureFlagOptionParserTest : Spek({
             val testCases = loadLinesFromFile("OPTION_VALID_SPACE")
 
             testCases.forEachIndexed { index, testValue ->
-                it(""""$testValue"""") {
+                test(""""$testValue"""") {
                     assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
                 }
             }
         }
     }
 
-    describe("Parsing is failed") {
-        it("with undefined option") {
+    context("Parsing is failed") {
+        test("with undefined option") {
             assertFailureMessage<IllegalArgumentException>(
                 "A specified option is undefined: INVALID"
             ) {

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagOptionParserTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagOptionParserTest.kt
@@ -20,10 +20,11 @@ import com.linecorp.android.featureflag.model.FeatureFlagOption
 import com.linecorp.android.featureflag.model.FeatureFlagOption.DEPRECATED
 import com.linecorp.android.featureflag.model.FeatureFlagOption.OVERRIDABLE
 import com.linecorp.android.featureflag.model.FeatureFlagOption.PRIVATE
-import com.linecorp.android.featureflag.utils.assertFailureMessage
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
 import java.io.File
-import kotlin.test.assertEquals
 
 /**
  * Tests for [FeatureFlagOptionParser].
@@ -39,12 +40,8 @@ class FeatureFlagOptionParserTest : FunSpec({
 
     context("Precondition") {
         test("A reverse map of Option enum is sufficient") {
-            val actualEnums = FeatureFlagOption.values().toList()
-            val reverseMapContainsEnums = FeatureFlagOptionParser.OPTION_MAPPING.values
-
-            assertEquals(actualEnums.size, reverseMapContainsEnums.size)
-            assertEquals(0, reverseMapContainsEnums.subtract(actualEnums).size)
-            assertEquals(0, actualEnums.subtract(reverseMapContainsEnums).size)
+            FeatureFlagOptionParser.OPTION_MAPPING.values shouldContainExactlyInAnyOrder
+                FeatureFlagOption.entries
         }
     }
 
@@ -61,14 +58,14 @@ class FeatureFlagOptionParserTest : FunSpec({
 
             testCases.forEachIndexed { index, testValue ->
                 test(testValue) {
-                    assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
+                    FeatureFlagOptionParser.parse(testValue) shouldBe expectedResults[index]
                 }
             }
         }
 
         context("with empty") {
             test("Empty option") {
-                assertEquals(emptySet<FeatureFlagOption>(), FeatureFlagOptionParser.parse(""))
+                FeatureFlagOptionParser.parse("") shouldBe emptySet()
             }
         }
 
@@ -87,7 +84,7 @@ class FeatureFlagOptionParserTest : FunSpec({
 
             testCases.forEachIndexed { index, testValue ->
                 test(testValue) {
-                    assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
+                    FeatureFlagOptionParser.parse(testValue) shouldBe expectedResults[index]
                 }
             }
         }
@@ -105,7 +102,7 @@ class FeatureFlagOptionParserTest : FunSpec({
 
             testCases.forEachIndexed { index, testValue ->
                 test(""""$testValue"""") {
-                    assertEquals(expectedResults[index], FeatureFlagOptionParser.parse(testValue))
+                    FeatureFlagOptionParser.parse(testValue) shouldBe expectedResults[index]
                 }
             }
         }
@@ -113,7 +110,7 @@ class FeatureFlagOptionParserTest : FunSpec({
 
     context("Parsing is failed") {
         test("with undefined option") {
-            assertFailureMessage<IllegalArgumentException>(
+            shouldThrowWithMessage<IllegalArgumentException>(
                 "A specified option is undefined: INVALID"
             ) {
                 FeatureFlagOptionParser.parse(

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
@@ -26,13 +26,12 @@ import com.linecorp.android.featureflag.utils.assertDisjunction
 import com.linecorp.android.featureflag.utils.assertFailureMessage
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import io.kotest.core.spec.style.FunSpec
 
 /**
  * Tests for [FeatureFlagSelectorEvaluator].
  */
-object FeatureFlagSelectorEvaluatorTest : Spek({
+class FeatureFlagSelectorEvaluatorTest : FunSpec({
     fun assertEvaluation(
         expectedDisjunction: Disjunction<FeatureFlagAppliedElement>,
         disjunction: Disjunction<FeatureFlagElement>,
@@ -47,7 +46,7 @@ object FeatureFlagSelectorEvaluatorTest : Spek({
         )
     )
 
-    describe("Evaluated result is correct") {
+    context("Evaluated result is correct") {
         context("on each element") {
             fun assertSingleLiteralEvaluation(
                 expectedElement: FeatureFlagAppliedElement,
@@ -63,90 +62,90 @@ object FeatureFlagSelectorEvaluatorTest : Spek({
                 userName
             )
 
-            it("enabled by phase") {
+            test("enabled by phase") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.Phase("PHASE"),
                     phasesMap = mapOf("PHASE" to true)
                 )
             }
-            it("disabled by phase") {
+            test("disabled by phase") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(false),
                     FeatureFlagElement.Phase("DISABLED_PHASE"),
                     phasesMap = mapOf("DISABLED_PHASE" to false)
                 )
             }
-            it("enabled by user") {
+            test("enabled by user") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.User("USERNAME"),
                     userName = "USERNAME"
                 )
             }
-            it("disabled by user") {
+            test("disabled by user") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(false),
                     FeatureFlagElement.User("DISABLED_USERNAME"),
                     userName = "USERNAME"
                 )
             }
-            it("enabled by version: same version") {
+            test("enabled by version: same version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.Version("1.2.3"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("enabled by version: newer patch version") {
+            test("enabled by version: newer patch version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.Version("1.2.2"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("enabled by version: newer minor version") {
+            test("enabled by version: newer minor version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.Version("1.1.0"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("enabled by version: newer major version") {
+            test("enabled by version: newer major version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(true),
                     FeatureFlagElement.Version("0.0.1"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("disabled by version: older patch version") {
+            test("disabled by version: older patch version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(false),
                     FeatureFlagElement.Version("1.2.4"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("disabled by version: older minor version") {
+            test("disabled by version: older minor version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(false),
                     FeatureFlagElement.Version("1.3.0"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("disabled by version: older major version") {
+            test("disabled by version: older major version") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Constant(false),
                     FeatureFlagElement.Version("2.0.0"),
                     applicationVersion = "1.2.3"
                 )
             }
-            it("link to self module flag") {
+            test("link to self module flag") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Variable(FlagLink("", "flagValue")),
                     FeatureFlagElement.Link(FlagLink("", "flagValue"))
                 )
             }
-            it("link to another module flag") {
+            test("link to another module flag") {
                 assertSingleLiteralEvaluation(
                     FeatureFlagAppliedElement.Variable(FlagLink("anotherModule", "flagValue")),
                     FeatureFlagElement.Link(FlagLink("anotherModule", "flagValue"))
@@ -155,7 +154,7 @@ object FeatureFlagSelectorEvaluatorTest : Spek({
         }
     }
 
-    describe("Model structure is same") {
+    context("Model structure is same") {
         fun assertStructureEvaluation(
             expectedDisjunction: Disjunction<FeatureFlagAppliedElement>,
             sourceDisjunction: Disjunction<FeatureFlagElement>
@@ -217,8 +216,8 @@ object FeatureFlagSelectorEvaluatorTest : Spek({
         }
     }
 
-    describe("Evaluating is failed") {
-        it("Unknown phase") {
+    context("Evaluating is failed") {
+        test("Unknown phase") {
             assertFailureMessage<IllegalArgumentException>("Unknown phase: PHASE") {
                 FeatureFlagSelectorEvaluator.evaluate(
                     disjunctionOf(conjunctionOf(FeatureFlagElement.Phase("PHASE"))),

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
@@ -23,9 +23,9 @@ import com.linecorp.android.featureflag.model.FeatureFlagAppliedElement
 import com.linecorp.android.featureflag.model.FeatureFlagElement
 import com.linecorp.android.featureflag.model.FlagLink
 import com.linecorp.android.featureflag.utils.assertDisjunction
-import com.linecorp.android.featureflag.utils.assertFailureMessage
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
 
 /**
@@ -218,7 +218,7 @@ class FeatureFlagSelectorEvaluatorTest : FunSpec({
 
     context("Evaluating is failed") {
         test("Unknown phase") {
-            assertFailureMessage<IllegalArgumentException>("Unknown phase: PHASE") {
+            shouldThrowWithMessage<IllegalArgumentException>("Unknown phase: PHASE") {
                 FeatureFlagSelectorEvaluator.evaluate(
                     disjunctionOf(conjunctionOf(FeatureFlagElement.Phase("PHASE"))),
                     BuildEnvironment(emptyMap(), Version.valueOf("1.0.0"), "")

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorEvaluatorTest.kt
@@ -16,12 +16,13 @@
 
 package com.linecorp.android.featureflag.loader
 
-import com.github.zafarkhaja.semver.Version
+import com.linecorp.android.featureflag.model.ApplicationVersion
 import com.linecorp.android.featureflag.model.BuildEnvironment
 import com.linecorp.android.featureflag.model.DisjunctionNormalForm.Disjunction
 import com.linecorp.android.featureflag.model.FeatureFlagAppliedElement
 import com.linecorp.android.featureflag.model.FeatureFlagElement
 import com.linecorp.android.featureflag.model.FlagLink
+import com.linecorp.android.featureflag.model.VersionNotation
 import com.linecorp.android.featureflag.utils.assertDisjunction
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
@@ -42,7 +43,11 @@ class FeatureFlagSelectorEvaluatorTest : FunSpec({
         expectedDisjunction,
         FeatureFlagSelectorEvaluator.evaluate(
             disjunction,
-            BuildEnvironment(phasesMap, Version.valueOf(applicationVersion), userName)
+            BuildEnvironment(
+                phasesMap,
+                ApplicationVersion.from(applicationVersion, VersionNotation.SEM_VER),
+                userName
+            )
         )
     )
 
@@ -221,7 +226,11 @@ class FeatureFlagSelectorEvaluatorTest : FunSpec({
             shouldThrowWithMessage<IllegalArgumentException>("Unknown phase: PHASE") {
                 FeatureFlagSelectorEvaluator.evaluate(
                     disjunctionOf(conjunctionOf(FeatureFlagElement.Phase("PHASE"))),
-                    BuildEnvironment(emptyMap(), Version.valueOf("1.0.0"), "")
+                    BuildEnvironment(
+                        emptyMap(),
+                        ApplicationVersion.from("1.0.0", VersionNotation.SEM_VER),
+                        ""
+                    )
                 )
             }
         }

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorParserTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorParserTest.kt
@@ -22,9 +22,9 @@ import com.linecorp.android.featureflag.model.FeatureFlagElement.User
 import com.linecorp.android.featureflag.model.FeatureFlagElement.Version
 import com.linecorp.android.featureflag.model.FlagLink
 import com.linecorp.android.featureflag.utils.assertDisjunction
-import com.linecorp.android.featureflag.utils.assertFailureMessage
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
 import java.io.File
 
@@ -131,7 +131,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
     context("Parsing is failed") {
         context("on each element type") {
             test("User element with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "Missing user name in user element."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -140,7 +140,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
                 }
             }
             test("Link element with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "Missing link value in link element."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -149,7 +149,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
                 }
             }
             test("Link element with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "Missing link value in link element."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -158,7 +158,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
                 }
             }
             test("Version element with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "Missing version value in version element."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -169,7 +169,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
         }
         context("on conjunction") {
             test("with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -178,7 +178,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
                 }
             }
             test("with only one sides value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -189,7 +189,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
         }
         context("on disjunction") {
             test("with no value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
                     FeatureFlagSelectorParser.parse(
@@ -198,7 +198,7 @@ class FeatureFlagSelectorParserTest : FunSpec({
                 }
             }
             test("with only one sides value") {
-                assertFailureMessage<IllegalArgumentException>(
+                shouldThrowWithMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
                     FeatureFlagSelectorParser.parse(

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorParserTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagSelectorParserTest.kt
@@ -25,15 +25,14 @@ import com.linecorp.android.featureflag.utils.assertDisjunction
 import com.linecorp.android.featureflag.utils.assertFailureMessage
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
+import io.kotest.core.spec.style.FunSpec
 import java.io.File
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 /**
  * Tests for [FeatureFlagSelectorParser].
  * All the text resources are in "tests/FeatureFlagSelectorParser/" directory.
  */
-object FeatureFlagSelectorParserTest : Spek({
+class FeatureFlagSelectorParserTest : FunSpec({
     fun loadLinesFromFile(name: String): List<String> {
         val url = checkNotNull(
             javaClass.classLoader.getResource("tests/FeatureFlagSelectorParserTest/$name")
@@ -41,7 +40,7 @@ object FeatureFlagSelectorParserTest : Spek({
         return File(url.toURI()).bufferedReader().lineSequence().toList()
     }
 
-    describe("Parsed result is correct") {
+    context("Parsed result is correct") {
         context("on each element type") {
             val expectedResults = listOf(
                 disjunctionOf(conjunctionOf(Phase("PHASE"))),
@@ -54,7 +53,7 @@ object FeatureFlagSelectorParserTest : Spek({
             val testCases = loadLinesFromFile("VALUE_VALID_ELEMENT_TYPES")
 
             testCases.forEachIndexed { index, testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertDisjunction(
                         expectedResults[index],
                         FeatureFlagSelectorParser.parse(testValue)
@@ -69,7 +68,7 @@ object FeatureFlagSelectorParserTest : Spek({
             val testCases = loadLinesFromFile("VALUE_VALID_NESTED_MODULE_LINK")
 
             testCases.forEach { testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertDisjunction(expected, FeatureFlagSelectorParser.parse(testValue))
                 }
             }
@@ -82,7 +81,7 @@ object FeatureFlagSelectorParserTest : Spek({
             val testCases = loadLinesFromFile("VALUE_VALID_DISJUNCTION_WITH_SPACE")
 
             testCases.forEach { testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertDisjunction(expected, FeatureFlagSelectorParser.parse(testValue))
                 }
             }
@@ -94,7 +93,7 @@ object FeatureFlagSelectorParserTest : Spek({
             val testCases = loadLinesFromFile("VALUE_VALID_CONJUNCTION_WITH_SPACE")
 
             testCases.forEach { testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertDisjunction(expected, FeatureFlagSelectorParser.parse(testValue))
                 }
             }
@@ -119,7 +118,7 @@ object FeatureFlagSelectorParserTest : Spek({
             val testCases = loadLinesFromFile("VALUE_VALID_DISJUNCTION_AND_CONJUNCTION")
 
             testCases.forEachIndexed { index, testValue ->
-                it(testValue) {
+                test(testValue) {
                     assertDisjunction(
                         expectedResults[index],
                         FeatureFlagSelectorParser.parse(testValue)
@@ -129,9 +128,9 @@ object FeatureFlagSelectorParserTest : Spek({
         }
     }
 
-    describe("Parsing is failed") {
+    context("Parsing is failed") {
         context("on each element type") {
-            it("User element with no value") {
+            test("User element with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "Missing user name in user element."
                 ) {
@@ -140,7 +139,7 @@ object FeatureFlagSelectorParserTest : Spek({
                     )
                 }
             }
-            it("Link element with no value") {
+            test("Link element with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "Missing link value in link element."
                 ) {
@@ -149,7 +148,7 @@ object FeatureFlagSelectorParserTest : Spek({
                     )
                 }
             }
-            it("Link element with no value") {
+            test("Link element with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "Missing link value in link element."
                 ) {
@@ -158,7 +157,7 @@ object FeatureFlagSelectorParserTest : Spek({
                     )
                 }
             }
-            it("Version element with no value") {
+            test("Version element with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "Missing version value in version element."
                 ) {
@@ -169,7 +168,7 @@ object FeatureFlagSelectorParserTest : Spek({
             }
         }
         context("on conjunction") {
-            it("with no value") {
+            test("with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
@@ -178,7 +177,7 @@ object FeatureFlagSelectorParserTest : Spek({
                     )
                 }
             }
-            it("with only one sides value") {
+            test("with only one sides value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
@@ -189,7 +188,7 @@ object FeatureFlagSelectorParserTest : Spek({
             }
         }
         context("on disjunction") {
-            it("with no value") {
+            test("with no value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {
@@ -198,7 +197,7 @@ object FeatureFlagSelectorParserTest : Spek({
                     )
                 }
             }
-            it("with only one sides value") {
+            test("with only one sides value") {
                 assertFailureMessage<IllegalArgumentException>(
                     "An invalid blank element exists."
                 ) {

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagValueOptimizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagValueOptimizerTest.kt
@@ -24,15 +24,14 @@ import com.linecorp.android.featureflag.model.FlagLink
 import com.linecorp.android.featureflag.utils.assertDisjunction
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
+import io.kotest.core.spec.style.FunSpec
 import kotlin.test.assertEquals
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import com.linecorp.android.featureflag.model.FeatureFlagAppliedElement as AppliedElement
 
 /**
  * Tests for [FeatureFlagValueOptimizer].
  */
-object FeatureFlagValueOptimizerTest : Spek({
+class FeatureFlagValueOptimizerTest : FunSpec({
     fun assertOptimization(
         expectedValue: Value,
         sourceDisjunction: Disjunction<AppliedElement>
@@ -45,27 +44,27 @@ object FeatureFlagValueOptimizerTest : Spek({
         }
     }
 
-    describe("Evaluated result is correct") {
+    context("Evaluated result is correct") {
         context("only single literal") {
-            it("constant: true") {
+            test("constant: true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(conjunctionOf(Constant(true)))
                 )
             }
-            it("constant: false") {
+            test("constant: false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(conjunctionOf(Constant(false)))
                 )
             }
-            it("link: self module") {
+            test("link: self module") {
                 assertOptimization(
                     Value.Links(disjunctionOf(conjunctionOf(FlagLink("", "flagName")))),
                     disjunctionOf(conjunctionOf(Variable(FlagLink("", "flagName"))))
                 )
             }
-            it("link: another module") {
+            test("link: another module") {
                 assertOptimization(
                     Value.Links(
                         disjunctionOf(conjunctionOf(FlagLink("anotherModule", "flagName")))
@@ -75,25 +74,25 @@ object FeatureFlagValueOptimizerTest : Spek({
             }
         }
         context("conjunction optimization") {
-            it("true & true => true") {
+            test("true & true => true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(conjunctionOf(Constant(true), Constant(true)))
                 )
             }
-            it("true & false => false") {
+            test("true & false => false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(conjunctionOf(Constant(true), Constant(false)))
                 )
             }
-            it("false & false => false") {
+            test("false & false => false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(conjunctionOf(Constant(false), Constant(false)))
                 )
             }
-            it("false & link => false") {
+            test("false & link => false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(
@@ -104,13 +103,13 @@ object FeatureFlagValueOptimizerTest : Spek({
                     )
                 )
             }
-            it("true & link => link") {
+            test("true & link => link") {
                 assertOptimization(
                     Value.Links(disjunctionOf(conjunctionOf(FlagLink("", "flagName")))),
                     disjunctionOf(conjunctionOf(Constant(true), Variable(FlagLink("", "flagName"))))
                 )
             }
-            it("true & false & link => false") {
+            test("true & false & link => false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(
@@ -122,7 +121,7 @@ object FeatureFlagValueOptimizerTest : Spek({
                     )
                 )
             }
-            it("link1 & link2 => link1 & link2") {
+            test("link1 & link2 => link1 & link2") {
                 assertOptimization(
                     Value.Links(
                         disjunctionOf(
@@ -142,25 +141,25 @@ object FeatureFlagValueOptimizerTest : Spek({
             }
         }
         context("disjunction optimization") {
-            it("true | true => true") {
+            test("true | true => true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(conjunctionOf(Constant(true)), conjunctionOf(Constant(true)))
                 )
             }
-            it("true | false => true") {
+            test("true | false => true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(conjunctionOf(Constant(true)), conjunctionOf(Constant(false)))
                 )
             }
-            it("false | false => false") {
+            test("false | false => false") {
                 assertOptimization(
                     Value.False,
                     disjunctionOf(conjunctionOf(Constant(false)), conjunctionOf(Constant(false)))
                 )
             }
-            it("false | link => link") {
+            test("false | link => link") {
                 assertOptimization(
                     Value.Links(disjunctionOf(conjunctionOf(FlagLink("", "flagName")))),
                     disjunctionOf(
@@ -169,7 +168,7 @@ object FeatureFlagValueOptimizerTest : Spek({
                     )
                 )
             }
-            it("true | link => true") {
+            test("true | link => true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(
@@ -178,7 +177,7 @@ object FeatureFlagValueOptimizerTest : Spek({
                     )
                 )
             }
-            it("true | false | link => true") {
+            test("true | false | link => true") {
                 assertOptimization(
                     Value.True,
                     disjunctionOf(
@@ -188,7 +187,7 @@ object FeatureFlagValueOptimizerTest : Spek({
                     )
                 )
             }
-            it("link1 | link2 => link1 | link2") {
+            test("link1 | link2 => link1 | link2") {
                 assertOptimization(
                     Value.Links(
                         disjunctionOf(

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagValueOptimizerTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/loader/FeatureFlagValueOptimizerTest.kt
@@ -25,7 +25,7 @@ import com.linecorp.android.featureflag.utils.assertDisjunction
 import com.linecorp.android.featureflag.utils.conjunctionOf
 import com.linecorp.android.featureflag.utils.disjunctionOf
 import io.kotest.core.spec.style.FunSpec
-import kotlin.test.assertEquals
+import io.kotest.matchers.shouldBe
 import com.linecorp.android.featureflag.model.FeatureFlagAppliedElement as AppliedElement
 
 /**
@@ -40,7 +40,7 @@ class FeatureFlagValueOptimizerTest : FunSpec({
         if (expectedValue is Value.Links && actualValue is Value.Links) {
             assertDisjunction(expectedValue.linksDisjunction, actualValue.linksDisjunction)
         } else {
-            assertEquals(expectedValue, actualValue)
+            actualValue shouldBe expectedValue
         }
     }
 

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SemVerApplicationVersionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SemVerApplicationVersionTest.kt
@@ -58,6 +58,7 @@ class SemVerApplicationVersionTest : FunSpec({
         test("minor version differences") {
             SemVer.from("1.2.0") shouldBeGreaterThan SemVer.from("1.1.9")
             SemVer.from("1.1.0") shouldBeLessThan SemVer.from("1.2.0")
+            SemVer.from("1.2.0") shouldBeLessThan SemVer.from("1.11.0")
         }
         test("patch version differences") {
             SemVer.from("1.2.3") shouldBeGreaterThan SemVer.from("1.2.2")

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SemVerApplicationVersionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SemVerApplicationVersionTest.kt
@@ -1,0 +1,72 @@
+package com.linecorp.android.featureflag.model
+
+import com.github.zafarkhaja.semver.Version
+import com.linecorp.android.featureflag.model.ApplicationVersion.SemVer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+
+class SemVerApplicationVersionTest : FunSpec({
+
+    context("instantiate") {
+        context("success") {
+            test("valid semantic version") {
+                SemVer.from("1.2.3").version shouldBe Version.parse("1.2.3")
+            }
+            test("version with pre-release") {
+                SemVer.from("1.2.3-alpha").version shouldBe Version.parse("1.2.3-alpha")
+            }
+            test("version with build metadata") {
+                SemVer.from("1.2.3+build.1").version shouldBe Version.parse("1.2.3+build.1")
+            }
+            test("version with pre-release and build metadata") {
+                SemVer.from("1.2.3-alpha+build.1").version shouldBe
+                    Version.parse("1.2.3-alpha+build.1")
+            }
+        }
+        context("failure") {
+            test("invalid version format") {
+                shouldThrow<Exception> {
+                    SemVer.from("1.2")
+                }
+                shouldThrow<Exception> {
+                    SemVer.from("1.2.a")
+                }
+                shouldThrow<Exception> {
+                    SemVer.from("invalid")
+                }
+            }
+            test("empty version") {
+                shouldThrow<Exception> {
+                    SemVer.from("")
+                }
+            }
+        }
+    }
+
+    context("comparison") {
+        test("equal versions") {
+            SemVer.from("1.2.3") shouldBeEqualComparingTo SemVer.from("1.2.3")
+        }
+        test("major version differences") {
+            SemVer.from("2.0.0") shouldBeGreaterThan SemVer.from("1.9.9")
+            SemVer.from("1.0.0") shouldBeLessThan SemVer.from("2.0.0")
+        }
+        test("minor version differences") {
+            SemVer.from("1.2.0") shouldBeGreaterThan SemVer.from("1.1.9")
+            SemVer.from("1.1.0") shouldBeLessThan SemVer.from("1.2.0")
+        }
+        test("patch version differences") {
+            SemVer.from("1.2.3") shouldBeGreaterThan SemVer.from("1.2.2")
+            SemVer.from("1.2.2") shouldBeLessThan SemVer.from("1.2.3")
+        }
+        test("pre-release versions") {
+            SemVer.from("1.2.3") shouldBeGreaterThan SemVer.from("1.2.3-alpha")
+            SemVer.from("1.2.3-beta") shouldBeGreaterThan SemVer.from("1.2.3-alpha")
+            SemVer.from("1.2.3-alpha.2") shouldBeGreaterThan SemVer.from("1.2.3-alpha.1")
+        }
+    }
+})

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SimpleApplicationVersionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SimpleApplicationVersionTest.kt
@@ -1,0 +1,145 @@
+package com.linecorp.android.featureflag.model
+
+import com.linecorp.android.featureflag.model.ApplicationVersion.Simple
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+
+class SimpleApplicationVersionTest : FunSpec({
+
+    context("instantiate") {
+        context("success") {
+            test("single number") {
+                Simple.from("1").versionNumberList shouldBe listOf(1)
+            }
+            test("multiple numbers") {
+                Simple.from("1.2.3").versionNumberList shouldBe listOf(1, 2, 3)
+            }
+            test("started by 0") {
+                Simple.from("0.01.10").versionNumberList shouldBe listOf(0, 1, 10)
+            }
+            test("zero only versions") {
+                Simple.from("0").versionNumberList shouldBe listOf(0)
+                Simple.from("0.0").versionNumberList shouldBe listOf(0, 0)
+                Simple.from("0.0.0").versionNumberList shouldBe listOf(0, 0, 0)
+            }
+            test("large numbers") {
+                Simple.from("2147483647").versionNumberList shouldBe listOf(2147483647)
+                Simple.from("999999999.888888888.777777777").versionNumberList shouldBe listOf(
+                    999999999,
+                    888888888,
+                    777777777
+                )
+            }
+        }
+        context("failure") {
+            test("not-number") {
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: a") {
+                    Simple.from("a")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 1.b") {
+                    Simple.from("1.b")
+                }
+            }
+            test("empty") {
+                shouldThrowWithMessage<IllegalArgumentException>("Input value is empty") {
+                    Simple.from("")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Input value is empty") {
+                    Simple.from(" ")
+                }
+            }
+            test("multi-dot") {
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 1..0") {
+                    Simple.from("1..0")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: ..0") {
+                    Simple.from("..0")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 0..") {
+                    Simple.from("0..")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: ..") {
+                    Simple.from("..")
+                }
+            }
+            test("leading or trailing dot") {
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: .1") {
+                    Simple.from(".1")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 1.") {
+                    Simple.from("1.")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: .1.2") {
+                    Simple.from(".1.2")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 1.2.") {
+                    Simple.from("1.2.")
+                }
+            }
+            test("negative numbers") {
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: -1") {
+                    Simple.from("-1")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 1.-2") {
+                    Simple.from("1.-2")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: -1.2.3") {
+                    Simple.from("-1.2.3")
+                }
+            }
+            test("number overflow") {
+                shouldThrowWithMessage<IllegalArgumentException>("Invalid version: 2147483648") {
+                    Simple.from("2147483648")
+                }
+                shouldThrowWithMessage<IllegalArgumentException>(
+                    "Invalid version: 99999999999999999999"
+                ) {
+                    Simple.from("99999999999999999999")
+                }
+            }
+        }
+    }
+
+    context("comparison") {
+        context("success") {
+            test("single number") {
+                Simple.from("2") shouldBeGreaterThan Simple.from("1")
+            }
+            test("multiple numbers") {
+                Simple.from("1.2") shouldBeGreaterThan Simple.from("1.1")
+                Simple.from("1.0.0") shouldBeEqualComparingTo Simple.from("1.0.0")
+                Simple.from("1.0.1") shouldBeGreaterThan Simple.from("1.0.0")
+                Simple.from("1.1.0") shouldBeGreaterThan Simple.from("1.0.0")
+                Simple.from("2.0.0") shouldBeGreaterThan Simple.from("1.0.0")
+                Simple.from("1.2.3.4") shouldBeGreaterThan Simple.from("0.2.3.4")
+            }
+            test("started by 0") {
+                Simple.from("1.02") shouldBeGreaterThan Simple.from("1.01")
+                Simple.from("1.00.0") shouldBeEqualComparingTo Simple.from("1.00.0")
+                Simple.from("1.00.01") shouldBeGreaterThan Simple.from("1.00.00")
+                Simple.from("1.01.0") shouldBeGreaterThan Simple.from("1.0.0")
+            }
+            test("boundary values") {
+                Simple.from("0") shouldBeEqualComparingTo Simple.from("0")
+                Simple.from("1") shouldBeGreaterThan Simple.from("0")
+                Simple.from("0.0.1") shouldBeGreaterThan Simple.from("0.0.0")
+            }
+            test("large number comparisons") {
+                Simple.from("2147483647") shouldBeGreaterThan Simple.from("2147483646")
+                Simple.from("999999999.0") shouldBeGreaterThan Simple.from("999999998.999999999")
+            }
+        }
+        context("failure") {
+            test("different dot count") {
+                shouldThrowWithMessage<IllegalArgumentException>(
+                    "Incompatible version format: 1.0 and 1.0.0"
+                ) {
+                    Simple.from("1.0") shouldBeEqualComparingTo Simple.from("1.0.0")
+                }
+            }
+        }
+    }
+})

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SimpleApplicationVersionTest.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/model/SimpleApplicationVersionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 
 class SimpleApplicationVersionTest : FunSpec({
@@ -115,6 +116,7 @@ class SimpleApplicationVersionTest : FunSpec({
                 Simple.from("1.1.0") shouldBeGreaterThan Simple.from("1.0.0")
                 Simple.from("2.0.0") shouldBeGreaterThan Simple.from("1.0.0")
                 Simple.from("1.2.3.4") shouldBeGreaterThan Simple.from("0.2.3.4")
+                Simple.from("1.2.0") shouldBeLessThan Simple.from("1.11.0")
             }
             test("started by 0") {
                 Simple.from("1.02") shouldBeGreaterThan Simple.from("1.01")

--- a/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/utils/AssertUtils.kt
+++ b/feature-flag/src/test/kotlin/com/linecorp/android/featureflag/utils/AssertUtils.kt
@@ -17,20 +17,7 @@
 package com.linecorp.android.featureflag.utils
 
 import com.linecorp.android.featureflag.model.DisjunctionNormalForm
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-
-/**
- * Asserts that a [block] operation fails with an exception, where the type is [T] and the message
- * is [failureMessage].
- */
-internal inline fun <reified T : Throwable> assertFailureMessage(
-    failureMessage: String,
-    block: () -> Unit
-) {
-    val exception = assertFailsWith<T> { block() }
-    assertEquals(failureMessage, exception.message)
-}
+import io.kotest.matchers.shouldBe
 
 /**
  * Asserts that the given two [DisjunctionNormalForm.Disjunction]s are equal.
@@ -41,8 +28,8 @@ internal fun <T> assertDisjunction(
     expected: DisjunctionNormalForm.Disjunction<out T>,
     actual: DisjunctionNormalForm.Disjunction<out T>
 ) {
-    assertEquals(expected.values.size, actual.values.size, "Disjunction sizes are different: ")
+    actual.values.size shouldBe expected.values.size
     expected.values.zip(actual.values).forEach { (expectedConjunction, actualConjunction) ->
-        assertEquals(expectedConjunction.values, actualConjunction.values)
+        actualConjunction.values shouldBe expectedConjunction.values
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,12 @@
 feature-flag = "3.2.0"
 
 # https://developer.android.com/studio/releases/gradle-plugin
-android-gradle = "8.9.2"
+android-gradle = "8.13.2"
 
 # Kotlin version should be fit with AGP's Kotlin version and Gradle's Kotlin version.
 # https://mvnrepository.com/artifact/com.android.tools.build/gradle
 # https://kotlinlang.org/docs/releases.html#release-details
-kotlin = "2.1.0"
+kotlin = "2.3.0"
 
 # https://github.com/JLLeitschuh/ktlint-gradle/releases
 ktlint-gradle = "12.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,8 +22,8 @@ ben-manes-gradle = "0.52.0"
 # https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 gradle-publish = "1.3.1"
 
-# https://github.com/spekframework/spek/releases
-spek = "2.0.19"
+# https://github.com/kotest/kotest/releases
+kotest = "6.0.7"
 
 # https://github.com/mockk/mockk/releases
 mockk = "1.14.0"
@@ -39,8 +39,9 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 
 jsemver = { module = "com.github.zafarkhaja:java-semver", version.ref = "jsemver" }
 
-spek2-dsl-jvm = { module = "org.spekframework.spek2:spek-dsl-jvm", version.ref = "spek" }
-spek2-runner-junit5 = { module = "org.spekframework.spek2:spek-runner-junit5", version.ref = "spek" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 


### PR DESCRIPTION
#52 

To enable this plugin for projects using versioning not covered by SemVer (such as those using zero-based numbering like CalVer), we will implement a switchable version interpretation method.
This time, we are adding a `SIMPLE` type that simply interprets numbers separated by dots as a version.

Additionally, since Spek2 is no longer being maintained, we will migrate to Kotest.